### PR TITLE
[doc]: add CHAOSS code of conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,118 @@
+# CHAOSS Community: Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to make participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, gender identity and expression, level of experience,
+education, socio-economic status, nationality, personal appearance, race,
+religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the CHAOSS Code of Conduct Team at 
+<chaoss-conduct@googlegroups.com>. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+We will respect confidentiality requests for the purpose of protecting victims
+of unacceptable behavior. At our discretion, we may publicly name a person about
+whom we’ve received unacceptable behavior complaints, or privately warn third
+parties about them, if we believe that doing so will increase the safety of
+CHAOSS members or the general public. We will not name victims without their
+affirmative consent.
+
+The CHAOSS Code of Conduct Team will report on a yearly basis the number of
+incidence reports. The CHAOSS Code of Conduct Team shall consist of three members 
+elected by the community every two years or when needed.
+
+## Who to Contact
+
+The following people comprise the CHAOSS Code of Conduct Team and are the only 
+recipients of <chaoss-conduct@googlegroups.com>:
+ - MaryBlessing Okolie 
+ - Georg Link
+ - Anita Ihuman
+
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][cc-homepage], version 1.4,
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+and the [Geek Feminism][gf-homepage] Code of Conduct,
+available at https://geekfeminism.org/about/code-of-conduct/
+
+[cc-homepage]: https://www.contributor-covenant.org
+[gf-homepage]: https://geekfeminism.org/
+
+## Version History
+
+* v1.3 New members were added from a Governing Board vote in January 2024
+
+* v1.2 update Code of Conduct Team based on [vote results](https://civs.cs.cornell.edu/cgi-bin/results.pl?id=E_eb0e86af55a181a9) on June 12, 2018
+
+* v1.1 proposed on April 2, 2018; accepted by CHAOSS Governing Board on May 1, 2018
+  - update email address
+  - change requirements for Code of Conduct team to be more inclusive
+  - change to three members of the team to have a tie-breaking vote
+
+* v1.0 adopted through a CHAOSS Governing Board vote from February 12, 2018
+
+* v1.0 proposed on [January 27, 2018](https://github.com/chaoss/governance/pull/3#issuecomment-360939881) by the working group consisting of:
+    * Alexander Serebrenik
+    * Georg Link
+    * Jesus M Gonzales-Barahona
+    * Ray Paik
+    * Sean Goggins
+    * Vicky Janicki

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ Before you get started, please take a moment to read through the following guide
 
 ## Code of Conduct
 
-Please note that this project has a [Code of Conduct](https://github.com/chaoss/.github/blob/main/CODE_OF_CONDUCT.md). We expect all contributors to adhere to it. Please take a moment to read through these guidelines to ensure a positive and inclusive contributor experience.
+Please note that this project has a [Code of Conduct](/CODE_OF_CONDUCT.md). We expect all contributors to adhere to it. Please take a moment to read through these guidelines to ensure a positive and inclusive contributor experience.
 
 ## Who can contribute?
 


### PR DESCRIPTION
**Summary:**

* Added the CHAOSS community code of conduct.

**Changes:**

* [Code of conduct](https://github.com/misspee007/badging/tree/doc/code-of-conduct?tab=coc-ov-file#chaoss-community-code-of-conduct)
* [Contributing.md](https://github.com/misspee007/badging/blob/doc/code-of-conduct/CONTRIBUTING.md#code-of-conduct): Edited link to code of conduct 

**Testing:**

N/A

**Additional Notes:**
Closes #116 