### PR TITLE
[FIX] Update workflow to use version 4 of the artifact actions.

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -24,7 +24,7 @@ jobs:
       - run: npm run build
 
       - name: Upload Build Artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: build
           path: build
@@ -37,7 +37,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Download Build Artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: build
           path: build


### PR DESCRIPTION
## Pull Request Template

**Summary:**

* This PR updates the artifact actions from deprecated version 2 to version 4 to fix workflow failure. 

**Changes:**

* Modified workflow.yml to change actions/upload-artifact@v2 to actions/upload-artifact@v4.
* Modified workflow.yml to change actions/download-artifact@v2 to actions/download-artifact@v4.
