### PR TITLE
fixed incorrect copyright text on website

### DIFF
--- a/src/components/Footer/Footer.js
+++ b/src/components/Footer/Footer.js
@@ -24,8 +24,7 @@ const Footer = () => {
         </Link>
       </span>
       <span className="copy-right">
-        Copyright &copy; <a href="/">CHAOSS.</a> All rights reserved a Linux
-        Foundation Project
+        Copyright &copy; <a href="/">CHAOSS.</a> A Linux Foundation Project. All rights reserved.
       </span>
     </footer>
   );


### PR DESCRIPTION
Fixed incorrect copyright text in the footer section
closes #143 


