### PR TITLE
Fix source path in pipeline.yml for deployment

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -58,7 +58,7 @@ jobs:
           host: ${{ secrets.HOST }}
           username: ${{ secrets.SSHUSERNAME }}
           password: ${{ secrets.SSHPASSWORD }}
-          source: "${{ github.workspace }}/build/*"
+          source: "/build/*"
           target: /var/www/badging.chaoss.community/
 
 


### PR DESCRIPTION


**Summary:**

This pull request makes a small update to the deployment configuration in the GitHub Actions workflow. The change modifies the source path for the deployment step to use an absolute path instead of a workspace-relative path.


**Changes:**

* Changed the `source` path in the `.github/workflows/pipeline.yml` deployment job from `"${{ github.workspace }}/build/*"` to `"/build/*"`.. 

