### PR TITLE
fix: correct copyright text formatting in footer

### DIFF
--- a/src/components/Footer/Footer.js
+++ b/src/components/Footer/Footer.js
@@ -21,8 +21,7 @@ const Footer = () => {
         </Link>
       </span>
       <span className="copy-right">
-        Copyright &copy; <a href="/">CHAOSS.</a> All rights reserved a Linux
-        Foundation Project
+        Copyright &copy; <a href="/">CHAOSS.</a> A Linux Foundation Project. All rights reserved.
       </span>
     </footer>
   );


### PR DESCRIPTION
## What this PR does
Fixes the incorrect copyright text in the website footer.

## Changes
Corrected formatting from:
"Copyright © CHAOSS. All rights reserved a Linux Foundation Project"

To:
"Copyright © CHAOSS. A Linux Foundation Project. All rights reserved."

Fixes #143